### PR TITLE
Add disable-sandbox flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -22,11 +22,12 @@ const cli = meow(`
    $ carbon-now <file>
 		
  ${chalk.bold('Options')}
-   -s, --start          Starting line of <file>
-   -e, --end            Ending line of <file>
-   -i, --interactive    Interactive mode
-   -l, --location       Screenshot save location, default: cwd
-   -o, --open           Open in browser instead of saving
+   -s, --start           Starting line of <file>
+   -e, --end             Ending line of <file>
+   -i, --interactive     Interactive mode
+   -l, --location        Screenshot save location, default: cwd
+	 -o, --open            Open in browser instead of saving
+	 -S, --disable-sandbox Disable sandbox
 
  ${chalk.bold('Examples')}
    See: https://github.com/mixn/carbon-now-cli#examples

--- a/cli.js
+++ b/cli.js
@@ -57,6 +57,11 @@ const cli = meow(`
 			type: 'boolean',
 			alias: 'i',
 			default: false
+		},
+		disableSandbox: {
+			type: 'boolean',
+			alias: 'S',
+			default: false
 		}
 	}
 });

--- a/cli.js
+++ b/cli.js
@@ -153,7 +153,7 @@ if (!file) {
   The file can be found here: ${downloadedFile} 😌`
 				);
 
-				if (process.env.TERM_PROGRAM.match('iTerm')) {
+				if (process.env.TERM_PROGRAM && process.env.TERM_PROGRAM.match('iTerm')) {
 					console.log(`
   iTerm2 should display the image below. 😊
 

--- a/cli.js
+++ b/cli.js
@@ -26,8 +26,8 @@ const cli = meow(`
    -e, --end             Ending line of <file>
    -i, --interactive     Interactive mode
    -l, --location        Screenshot save location, default: cwd
-	 -o, --open            Open in browser instead of saving
-	 -S, --disable-sandbox Disable sandbox
+   -o, --open            Open in browser instead of saving
+   -S, --disable-sandbox Disable sandbox
 
  ${chalk.bold('Examples')}
    See: https://github.com/mixn/carbon-now-cli#examples

--- a/cli.js
+++ b/cli.js
@@ -66,7 +66,7 @@ const cli = meow(`
 	}
 });
 const [file] = cli.input;
-const {start, end, open, location, interactive} = cli.flags;
+const {start, end, open, location, interactive, disableSandbox} = cli.flags;
 let url = 'https://carbon.now.sh/';
 
 // Deny everything if not at least one argument (file) specified
@@ -128,7 +128,7 @@ if (!file) {
 		{
 			title: 'Fetching beautiful image',
 			skip: () => open,
-			task: () => headlessVisit(url, location, settings.type)
+			task: () => headlessVisit(url, location, settings.type, disableSandbox)
 		}
 	]);
 

--- a/readme.md
+++ b/readme.md
@@ -65,11 +65,12 @@ Usage
   $ carbon-now <file>
 
 Options
-  -s, --start          Starting line of <file>
-  -e, --end            Ending line of <file>
-  -i, --interactive    Interactive mode
-  -l, --location       Image save location, default: cwd
-  -o, --open           Open in browser instead of saving
+  -s, --start           Starting line of <file>
+  -e, --end             Ending line of <file>
+  -i, --interactive     Interactive mode
+  -l, --location        Image save location, default: cwd
+  -o, --open            Open in browser instead of saving
+  -S, --disable-sandbox Disable sandbox
 ```
 
 ## Examples

--- a/src/headless-visit.js
+++ b/src/headless-visit.js
@@ -1,10 +1,11 @@
 // Packages
 const puppeteer = require('puppeteer');
 
-module.exports = async (url, location = process.cwd(), type = 'png') => {
+module.exports = async (url, location = process.cwd(), type = 'png', disableSandbox = false) => {
 	// Launch browser
 	const browser = await puppeteer.launch({
-		headless: false
+		headless: false,
+		args: disableSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
 	});
 	// Open new page
 	const page = await browser.newPage();


### PR DESCRIPTION
Adds a new flag which disables chromes sandbox.
Some users are having troubles due to chrome complaining about being unable to get a sandbox.
As it is not fixable for all users by upgrading kernel or something it should be able to turn of chromes sandbox feature over cli.
Fixes #9 