### PR TITLE
download behaviour change

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -22,11 +22,12 @@ const cli = meow(`
    $ carbon-now <file>
 		
  ${chalk.bold('Options')}
-   -s, --start          Starting line of <file>
-   -e, --end            Ending line of <file>
-   -i, --interactive    Interactive mode
-   -l, --location       Screenshot save location, default: cwd
-   -o, --open           Open in browser instead of saving
+   -s, --start           Starting line of <file>
+   -e, --end             Ending line of <file>
+   -i, --interactive     Interactive mode
+   -l, --location        Screenshot save location, default: cwd
+	 -o, --open            Open in browser instead of saving
+	 -S, --disable-sandbox Disable sandbox
 
  ${chalk.bold('Examples')}
    See: https://github.com/mixn/carbon-now-cli#examples

--- a/cli.js
+++ b/cli.js
@@ -57,6 +57,11 @@ const cli = meow(`
 			type: 'boolean',
 			alias: 'i',
 			default: false
+		},
+		disableSandbox: {
+			type: 'boolean',
+			alias: 'S',
+			default: false
 		}
 	}
 });

--- a/cli.js
+++ b/cli.js
@@ -153,7 +153,7 @@ if (!file) {
   The file can be found here: ${downloadedFile} 😌`
 				);
 
-				if (process.env.TERM_PROGRAM.match('iTerm')) {
+				if (process.env.TERM_PROGRAM && process.env.TERM_PROGRAM.match('iTerm')) {
 					console.log(`
   iTerm2 should display the image below. 😊
 

--- a/cli.js
+++ b/cli.js
@@ -26,8 +26,8 @@ const cli = meow(`
    -e, --end             Ending line of <file>
    -i, --interactive     Interactive mode
    -l, --location        Screenshot save location, default: cwd
-	 -o, --open            Open in browser instead of saving
-	 -S, --disable-sandbox Disable sandbox
+   -o, --open            Open in browser instead of saving
+   -S, --disable-sandbox Disable sandbox
 
  ${chalk.bold('Examples')}
    See: https://github.com/mixn/carbon-now-cli#examples

--- a/cli.js
+++ b/cli.js
@@ -66,7 +66,7 @@ const cli = meow(`
 	}
 });
 const [file] = cli.input;
-const {start, end, open, location, interactive} = cli.flags;
+const {start, end, open, location, interactive, disableSandbox} = cli.flags;
 let url = 'https://carbon.now.sh/';
 
 // Deny everything if not at least one argument (file) specified
@@ -128,7 +128,7 @@ if (!file) {
 		{
 			title: 'Fetching beautiful image',
 			skip: () => open,
-			task: () => headlessVisit(url, location, settings.type)
+			task: () => headlessVisit(url, location, settings.type, disableSandbox)
 		}
 	]);
 

--- a/cli.js
+++ b/cli.js
@@ -129,7 +129,7 @@ if (!file) {
 		{
 			title: 'Fetching beautiful image',
 			skip: () => open,
-			task: () => headlessVisit(url, location, settings.type, disableSandbox)
+			task: () => headlessVisit(url, location, settings, disableSandbox)
 		}
 	]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3295,6 +3295,16 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"fs-extra": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+			"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4647,6 +4657,14 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"kind-of": {
 			"version": "3.2.2",
@@ -7113,6 +7131,11 @@
 				"os-tmpdir": "^1.0.1",
 				"uid2": "0.0.3"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"unpipe": {
 			"version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,18 +16,18 @@
 			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"package-hash": "1.2.0"
+				"babel-plugin-check-es2015-constants": "^6.8.0",
+				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
+				"babel-plugin-transform-async-to-generator": "^6.16.0",
+				"babel-plugin-transform-es2015-destructuring": "^6.19.0",
+				"babel-plugin-transform-es2015-function-name": "^6.9.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
+				"babel-plugin-transform-es2015-parameters": "^6.21.0",
+				"babel-plugin-transform-es2015-spread": "^6.8.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
+				"babel-plugin-transform-exponentiation-operator": "^6.8.0",
+				"package-hash": "^1.2.0"
 			},
 			"dependencies": {
 				"md5-hex": {
@@ -36,7 +36,7 @@
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"package-hash": {
@@ -45,7 +45,7 @@
 					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
 					"dev": true,
 					"requires": {
-						"md5-hex": "1.3.0"
+						"md5-hex": "^1.3.0"
 					}
 				}
 			}
@@ -56,8 +56,8 @@
 			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
 			"dev": true,
 			"requires": {
-				"@ava/babel-plugin-throws-helper": "2.0.0",
-				"babel-plugin-espower": "2.4.0"
+				"@ava/babel-plugin-throws-helper": "^2.0.0",
+				"babel-plugin-espower": "^2.3.2"
 			}
 		},
 		"@ava/write-file-atomic": {
@@ -66,9 +66,9 @@
 			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"slide": "1.1.6"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"slide": "^1.1.5"
 			}
 		},
 		"@concordance/react": {
@@ -77,7 +77,7 @@
 			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1"
+				"arrify": "^1.0.1"
 			}
 		},
 		"@ladjs/time-require": {
@@ -86,10 +86,10 @@
 			"integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "0.4.0",
-				"date-time": "0.1.1",
-				"pretty-ms": "0.2.2",
-				"text-table": "0.2.0"
+				"chalk": "^0.4.0",
+				"date-time": "^0.1.1",
+				"pretty-ms": "^0.2.1",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -104,9 +104,9 @@
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "1.0.0",
-						"has-color": "0.1.7",
-						"strip-ansi": "0.1.1"
+						"ansi-styles": "~1.0.0",
+						"has-color": "~0.1.0",
+						"strip-ansi": "~0.1.0"
 					}
 				},
 				"pretty-ms": {
@@ -115,7 +115,7 @@
 					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
 					"dev": true,
 					"requires": {
-						"parse-ms": "0.1.2"
+						"parse-ms": "^0.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -131,8 +131,8 @@
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
 			"requires": {
-				"call-me-maybe": "1.0.1",
-				"glob-to-regexp": "0.3.0"
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
 			}
 		},
 		"@nodelib/fs.stat": {
@@ -145,7 +145,7 @@
 			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
 			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
 			"requires": {
-				"any-observable": "0.3.0"
+				"any-observable": "^0.3.0"
 			}
 		},
 		"@sindresorhus/jimp": {
@@ -153,19 +153,19 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/jimp/-/jimp-0.3.0.tgz",
 			"integrity": "sha512-ikwHOfJF0umx1eV/JpQDMsFxODvCSdD9zdIQVDEjcTNpfofz7+PZrjfKUFkG3iQ9mSUG3BwODv0XOEvTRNdovw==",
 			"requires": {
-				"bignumber.js": "2.4.0",
+				"bignumber.js": "^2.1.0",
 				"bmp-js": "0.0.3",
-				"exif-parser": "0.1.12",
-				"file-type": "3.9.0",
-				"jpeg-js": "0.2.0",
-				"load-bmfont": "1.3.0",
-				"mime": "1.6.0",
+				"exif-parser": "^0.1.9",
+				"file-type": "^3.1.0",
+				"jpeg-js": "^0.2.0",
+				"load-bmfont": "^1.2.3",
+				"mime": "^1.3.4",
 				"mkdirp": "0.5.1",
-				"pixelmatch": "4.0.2",
-				"pngjs": "3.3.3",
-				"raw-body": "2.3.3",
-				"tinycolor2": "1.4.1",
-				"utif": "1.3.0"
+				"pixelmatch": "^4.0.0",
+				"pngjs": "^3.0.0",
+				"raw-body": "^2.3.2",
+				"tinycolor2": "^1.1.2",
+				"utif": "^1.1.2"
 			},
 			"dependencies": {
 				"mime": {
@@ -187,7 +187,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0"
+				"acorn": "^3.0.4"
 			},
 			"dependencies": {
 				"acorn": {
@@ -203,7 +203,7 @@
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
 			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
 			"requires": {
-				"es6-promisify": "5.0.0"
+				"es6-promisify": "^5.0.0"
 			}
 		},
 		"ajv": {
@@ -212,10 +212,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ajv-keywords": {
@@ -230,7 +230,7 @@
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^2.0.0"
 			}
 		},
 		"ansi-escapes": {
@@ -248,7 +248,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
-				"color-convert": "1.9.2"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"any-observable": {
@@ -262,8 +262,8 @@
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 			"dev": true,
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
+				"micromatch": "^2.1.5",
+				"normalize-path": "^2.0.0"
 			}
 		},
 		"app-path": {
@@ -271,7 +271,7 @@
 			"resolved": "https://registry.npmjs.org/app-path/-/app-path-2.2.0.tgz",
 			"integrity": "sha1-KvXCtUSkDhX8GsVVSDFDl0YIRdA=",
 			"requires": {
-				"execa": "0.4.0"
+				"execa": "^0.4.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -279,12 +279,12 @@
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
 					"integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
 					"requires": {
-						"cross-spawn-async": "2.2.5",
-						"is-stream": "1.1.0",
-						"npm-run-path": "1.0.0",
-						"object-assign": "4.1.1",
-						"path-key": "1.0.0",
-						"strip-eof": "1.0.0"
+						"cross-spawn-async": "^2.1.1",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^1.0.0",
+						"object-assign": "^4.0.1",
+						"path-key": "^1.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"npm-run-path": {
@@ -292,7 +292,7 @@
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
 					"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
 					"requires": {
-						"path-key": "1.0.0"
+						"path-key": "^1.0.0"
 					}
 				},
 				"path-key": {
@@ -308,7 +308,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -317,7 +317,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-exclude": {
@@ -352,7 +352,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -404,89 +404,89 @@
 			"integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
 			"dev": true,
 			"requires": {
-				"@ava/babel-preset-stage-4": "1.1.0",
-				"@ava/babel-preset-transform-test-files": "3.0.0",
-				"@ava/write-file-atomic": "2.2.0",
-				"@concordance/react": "1.0.0",
-				"@ladjs/time-require": "0.1.4",
-				"ansi-escapes": "3.1.0",
-				"ansi-styles": "3.2.1",
-				"arr-flatten": "1.1.0",
-				"array-union": "1.0.2",
-				"array-uniq": "1.0.3",
-				"arrify": "1.0.1",
-				"auto-bind": "1.2.1",
-				"ava-init": "0.2.1",
-				"babel-core": "6.26.3",
-				"babel-generator": "6.26.1",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"bluebird": "3.5.1",
-				"caching-transform": "1.0.1",
-				"chalk": "2.4.1",
-				"chokidar": "1.7.0",
-				"clean-stack": "1.3.0",
-				"clean-yaml-object": "0.1.0",
-				"cli-cursor": "2.1.0",
-				"cli-spinners": "1.3.1",
-				"cli-truncate": "1.1.0",
-				"co-with-promise": "4.6.0",
-				"code-excerpt": "2.1.1",
-				"common-path-prefix": "1.0.0",
-				"concordance": "3.0.0",
-				"convert-source-map": "1.5.1",
-				"core-assert": "0.2.1",
-				"currently-unhandled": "0.4.1",
-				"debug": "3.1.0",
-				"dot-prop": "4.2.0",
-				"empower-core": "0.6.2",
-				"equal-length": "1.0.1",
-				"figures": "2.0.0",
-				"find-cache-dir": "1.0.0",
-				"fn-name": "2.0.1",
-				"get-port": "3.2.0",
-				"globby": "6.1.0",
-				"has-flag": "2.0.0",
-				"hullabaloo-config-manager": "1.1.1",
-				"ignore-by-default": "1.0.1",
-				"import-local": "0.1.1",
-				"indent-string": "3.2.0",
-				"is-ci": "1.1.0",
-				"is-generator-fn": "1.0.0",
-				"is-obj": "1.0.1",
-				"is-observable": "1.1.0",
-				"is-promise": "2.1.0",
-				"last-line-stream": "1.0.0",
-				"lodash.clonedeepwith": "4.5.0",
-				"lodash.debounce": "4.0.8",
-				"lodash.difference": "4.5.0",
-				"lodash.flatten": "4.4.0",
-				"loud-rejection": "1.6.0",
-				"make-dir": "1.3.0",
-				"matcher": "1.1.1",
-				"md5-hex": "2.0.0",
-				"meow": "3.7.0",
-				"ms": "2.1.1",
-				"multimatch": "2.1.0",
-				"observable-to-promise": "0.5.0",
-				"option-chain": "1.0.0",
-				"package-hash": "2.0.0",
-				"pkg-conf": "2.1.0",
-				"plur": "2.1.2",
-				"pretty-ms": "3.2.0",
-				"require-precompiled": "0.1.0",
-				"resolve-cwd": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"semver": "5.5.0",
-				"slash": "1.0.0",
-				"source-map-support": "0.5.6",
-				"stack-utils": "1.0.1",
-				"strip-ansi": "4.0.0",
-				"strip-bom-buf": "1.0.0",
-				"supertap": "1.0.0",
-				"supports-color": "5.4.0",
-				"trim-off-newlines": "1.0.1",
-				"unique-temp-dir": "1.0.0",
-				"update-notifier": "2.5.0"
+				"@ava/babel-preset-stage-4": "^1.1.0",
+				"@ava/babel-preset-transform-test-files": "^3.0.0",
+				"@ava/write-file-atomic": "^2.2.0",
+				"@concordance/react": "^1.0.0",
+				"@ladjs/time-require": "^0.1.4",
+				"ansi-escapes": "^3.0.0",
+				"ansi-styles": "^3.1.0",
+				"arr-flatten": "^1.0.1",
+				"array-union": "^1.0.1",
+				"array-uniq": "^1.0.2",
+				"arrify": "^1.0.0",
+				"auto-bind": "^1.1.0",
+				"ava-init": "^0.2.0",
+				"babel-core": "^6.17.0",
+				"babel-generator": "^6.26.0",
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+				"bluebird": "^3.0.0",
+				"caching-transform": "^1.0.0",
+				"chalk": "^2.0.1",
+				"chokidar": "^1.4.2",
+				"clean-stack": "^1.1.1",
+				"clean-yaml-object": "^0.1.0",
+				"cli-cursor": "^2.1.0",
+				"cli-spinners": "^1.0.0",
+				"cli-truncate": "^1.0.0",
+				"co-with-promise": "^4.6.0",
+				"code-excerpt": "^2.1.1",
+				"common-path-prefix": "^1.0.0",
+				"concordance": "^3.0.0",
+				"convert-source-map": "^1.5.1",
+				"core-assert": "^0.2.0",
+				"currently-unhandled": "^0.4.1",
+				"debug": "^3.0.1",
+				"dot-prop": "^4.1.0",
+				"empower-core": "^0.6.1",
+				"equal-length": "^1.0.0",
+				"figures": "^2.0.0",
+				"find-cache-dir": "^1.0.0",
+				"fn-name": "^2.0.0",
+				"get-port": "^3.0.0",
+				"globby": "^6.0.0",
+				"has-flag": "^2.0.0",
+				"hullabaloo-config-manager": "^1.1.0",
+				"ignore-by-default": "^1.0.0",
+				"import-local": "^0.1.1",
+				"indent-string": "^3.0.0",
+				"is-ci": "^1.0.7",
+				"is-generator-fn": "^1.0.0",
+				"is-obj": "^1.0.0",
+				"is-observable": "^1.0.0",
+				"is-promise": "^2.1.0",
+				"last-line-stream": "^1.0.0",
+				"lodash.clonedeepwith": "^4.5.0",
+				"lodash.debounce": "^4.0.3",
+				"lodash.difference": "^4.3.0",
+				"lodash.flatten": "^4.2.0",
+				"loud-rejection": "^1.2.0",
+				"make-dir": "^1.0.0",
+				"matcher": "^1.0.0",
+				"md5-hex": "^2.0.0",
+				"meow": "^3.7.0",
+				"ms": "^2.0.0",
+				"multimatch": "^2.1.0",
+				"observable-to-promise": "^0.5.0",
+				"option-chain": "^1.0.0",
+				"package-hash": "^2.0.0",
+				"pkg-conf": "^2.0.0",
+				"plur": "^2.0.0",
+				"pretty-ms": "^3.0.0",
+				"require-precompiled": "^0.1.0",
+				"resolve-cwd": "^2.0.0",
+				"safe-buffer": "^5.1.1",
+				"semver": "^5.4.1",
+				"slash": "^1.0.0",
+				"source-map-support": "^0.5.0",
+				"stack-utils": "^1.0.1",
+				"strip-ansi": "^4.0.0",
+				"strip-bom-buf": "^1.0.0",
+				"supertap": "^1.0.0",
+				"supports-color": "^5.0.0",
+				"trim-off-newlines": "^1.0.1",
+				"unique-temp-dir": "^1.0.0",
+				"update-notifier": "^2.3.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -501,8 +501,8 @@
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "2.1.1",
-						"map-obj": "1.0.1"
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
 					}
 				},
 				"find-up": {
@@ -511,8 +511,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"globby": {
@@ -521,11 +521,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -534,11 +534,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"map-obj": {
@@ -553,16 +553,16 @@
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "2.1.0",
-						"decamelize": "1.2.0",
-						"loud-rejection": "1.6.0",
-						"map-obj": "1.0.1",
-						"minimist": "1.2.0",
-						"normalize-package-data": "2.4.0",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"redent": "1.0.0",
-						"trim-newlines": "1.0.0"
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
 					}
 				},
 				"minimist": {
@@ -577,7 +577,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"path-exists": {
@@ -586,7 +586,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -595,9 +595,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -618,7 +618,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -627,9 +627,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -638,8 +638,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"redent": {
@@ -648,8 +648,8 @@
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 					"dev": true,
 					"requires": {
-						"indent-string": "2.1.0",
-						"strip-indent": "1.0.1"
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
 					},
 					"dependencies": {
 						"indent-string": {
@@ -658,7 +658,7 @@
 							"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 							"dev": true,
 							"requires": {
-								"repeating": "2.0.1"
+								"repeating": "^2.0.0"
 							}
 						}
 					}
@@ -669,7 +669,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-indent": {
@@ -678,7 +678,7 @@
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"dev": true,
 					"requires": {
-						"get-stdin": "4.0.1"
+						"get-stdin": "^4.0.1"
 					}
 				},
 				"trim-newlines": {
@@ -695,11 +695,11 @@
 			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
 			"dev": true,
 			"requires": {
-				"arr-exclude": "1.0.0",
-				"execa": "0.7.0",
-				"has-yarn": "1.0.0",
-				"read-pkg-up": "2.0.0",
-				"write-pkg": "3.2.0"
+				"arr-exclude": "^1.0.0",
+				"execa": "^0.7.0",
+				"has-yarn": "^1.0.0",
+				"read-pkg-up": "^2.0.0",
+				"write-pkg": "^3.1.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -708,13 +708,13 @@
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -723,10 +723,10 @@
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"parse-json": {
@@ -735,7 +735,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"path-type": {
@@ -744,7 +744,7 @@
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"dev": true,
 					"requires": {
-						"pify": "2.3.0"
+						"pify": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -759,9 +759,9 @@
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -770,8 +770,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "2.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
 					}
 				}
 			}
@@ -782,9 +782,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -799,11 +799,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -812,7 +812,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -829,25 +829,25 @@
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.1",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.1",
+				"debug": "^2.6.9",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.8",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -873,14 +873,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -897,9 +897,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-assignable-expression": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -908,10 +908,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -920,9 +920,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -931,11 +931,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -944,8 +944,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -954,8 +954,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
@@ -964,9 +964,9 @@
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -975,11 +975,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -988,8 +988,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-messages": {
@@ -998,7 +998,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -1007,7 +1007,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-espower": {
@@ -1016,13 +1016,13 @@
 			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babylon": "6.18.0",
-				"call-matcher": "1.0.1",
-				"core-js": "2.5.7",
-				"espower-location-detector": "1.0.0",
-				"espurify": "1.8.0",
-				"estraverse": "4.2.0"
+				"babel-generator": "^6.1.0",
+				"babylon": "^6.1.0",
+				"call-matcher": "^1.0.0",
+				"core-js": "^2.0.0",
+				"espower-location-detector": "^1.0.0",
+				"espurify": "^1.6.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -1055,9 +1055,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-functions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1066,7 +1066,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1075,9 +1075,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1086,10 +1086,10 @@
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1098,12 +1098,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1112,7 +1112,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1121,9 +1121,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1132,9 +1132,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1143,9 +1143,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1154,8 +1154,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-register": {
@@ -1164,13 +1164,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.3",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.7",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.10",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			},
 			"dependencies": {
 				"source-map-support": {
@@ -1179,7 +1179,7 @@
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
-						"source-map": "0.5.7"
+						"source-map": "^0.5.6"
 					}
 				}
 			}
@@ -1190,8 +1190,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"babel-template": {
@@ -1200,11 +1200,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.10"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1213,15 +1213,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"debug": {
@@ -1247,10 +1247,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"babylon": {
@@ -1269,13 +1269,13 @@
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1283,7 +1283,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1291,7 +1291,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1299,7 +1299,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1307,9 +1307,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"isobject": {
@@ -1357,13 +1357,13 @@
 			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 			"dev": true,
 			"requires": {
-				"ansi-align": "2.0.0",
-				"camelcase": "4.1.0",
-				"chalk": "2.4.1",
-				"cli-boxes": "1.0.0",
-				"string-width": "2.1.1",
-				"term-size": "1.2.0",
-				"widest-line": "2.0.0"
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^2.0.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^1.2.0",
+				"widest-line": "^2.0.0"
 			}
 		},
 		"brace-expansion": {
@@ -1371,7 +1371,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1381,9 +1381,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"buf-compare": {
@@ -1417,15 +1417,15 @@
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -1441,9 +1441,9 @@
 			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
 			"dev": true,
 			"requires": {
-				"md5-hex": "1.3.0",
-				"mkdirp": "0.5.1",
-				"write-file-atomic": "1.3.4"
+				"md5-hex": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"write-file-atomic": "^1.1.4"
 			},
 			"dependencies": {
 				"md5-hex": {
@@ -1452,7 +1452,7 @@
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
 					"dev": true,
 					"requires": {
-						"md5-o-matic": "0.1.1"
+						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"write-file-atomic": {
@@ -1461,9 +1461,9 @@
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"slide": "1.1.6"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
 					}
 				}
 			}
@@ -1474,10 +1474,10 @@
 			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7",
-				"deep-equal": "1.0.1",
-				"espurify": "1.8.0",
-				"estraverse": "4.2.0"
+				"core-js": "^2.0.0",
+				"deep-equal": "^1.0.0",
+				"espurify": "^1.6.0",
+				"estraverse": "^4.0.0"
 			}
 		},
 		"call-me-maybe": {
@@ -1497,7 +1497,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "^0.2.0"
 			}
 		},
 		"callsites": {
@@ -1516,9 +1516,9 @@
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 			"requires": {
-				"camelcase": "4.1.0",
-				"map-obj": "2.0.0",
-				"quick-lru": "1.1.0"
+				"camelcase": "^4.1.0",
+				"map-obj": "^2.0.0",
+				"quick-lru": "^1.0.0"
 			}
 		},
 		"capture-stack-trace": {
@@ -1532,9 +1532,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.4.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
@@ -1548,15 +1548,15 @@
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"dev": true,
 			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.2.4",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"anymatch": "^1.3.0",
+				"async-each": "^1.0.0",
+				"fsevents": "^1.0.0",
+				"glob-parent": "^2.0.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^2.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0"
 			}
 		},
 		"ci-info": {
@@ -1576,10 +1576,10 @@
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1587,7 +1587,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"isobject": {
@@ -1603,7 +1603,7 @@
 			"integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"clean-stack": {
@@ -1629,7 +1629,7 @@
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -1644,8 +1644,8 @@
 			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
 			"dev": true,
 			"requires": {
-				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"slice-ansi": "^1.0.0",
+				"string-width": "^2.0.0"
 			}
 		},
 		"cli-width": {
@@ -1665,7 +1665,7 @@
 			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
 			"dev": true,
 			"requires": {
-				"pinkie-promise": "1.0.0"
+				"pinkie-promise": "^1.0.0"
 			}
 		},
 		"code-excerpt": {
@@ -1674,7 +1674,7 @@
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
 			"dev": true,
 			"requires": {
-				"convert-to-spaces": "1.0.2"
+				"convert-to-spaces": "^1.0.1"
 			}
 		},
 		"code-point-at": {
@@ -1687,8 +1687,8 @@
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color-convert": {
@@ -1731,10 +1731,10 @@
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
-				"buffer-from": "1.1.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"concordance": {
@@ -1743,17 +1743,17 @@
 			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
 			"dev": true,
 			"requires": {
-				"date-time": "2.1.0",
-				"esutils": "2.0.2",
-				"fast-diff": "1.1.2",
-				"function-name-support": "0.2.0",
-				"js-string-escape": "1.0.1",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.flattendeep": "4.4.0",
-				"lodash.merge": "4.6.1",
-				"md5-hex": "2.0.0",
-				"semver": "5.5.0",
-				"well-known-symbols": "1.0.0"
+				"date-time": "^2.1.0",
+				"esutils": "^2.0.2",
+				"fast-diff": "^1.1.1",
+				"function-name-support": "^0.2.0",
+				"js-string-escape": "^1.0.1",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.flattendeep": "^4.4.0",
+				"lodash.merge": "^4.6.0",
+				"md5-hex": "^2.0.0",
+				"semver": "^5.3.0",
+				"well-known-symbols": "^1.0.0"
 			},
 			"dependencies": {
 				"date-time": {
@@ -1762,7 +1762,7 @@
 					"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
 					"dev": true,
 					"requires": {
-						"time-zone": "1.0.0"
+						"time-zone": "^1.0.0"
 					}
 				}
 			}
@@ -1773,12 +1773,12 @@
 			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "4.2.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.3.0",
-				"unique-string": "1.0.0",
-				"write-file-atomic": "2.3.0",
-				"xdg-basedir": "3.0.0"
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
 			}
 		},
 		"contains-path": {
@@ -1810,8 +1810,8 @@
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
 			"dev": true,
 			"requires": {
-				"buf-compare": "1.0.1",
-				"is-error": "2.2.1"
+				"buf-compare": "^1.0.0",
+				"is-error": "^2.2.0"
 			}
 		},
 		"core-js": {
@@ -1831,7 +1831,7 @@
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"dev": true,
 			"requires": {
-				"capture-stack-trace": "1.0.0"
+				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -1840,9 +1840,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.3",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cross-spawn-async": {
@@ -1850,8 +1850,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
 			"integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
 			"requires": {
-				"lru-cache": "4.1.3",
-				"which": "1.3.1"
+				"lru-cache": "^4.0.0",
+				"which": "^1.2.8"
 			}
 		},
 		"crypto-random-string": {
@@ -1865,7 +1865,7 @@
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"date-fns": {
@@ -1904,8 +1904,8 @@
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"requires": {
-				"decamelize": "1.2.0",
-				"map-obj": "1.0.1"
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
 			},
 			"dependencies": {
 				"map-obj": {
@@ -1944,7 +1944,7 @@
 			"integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
 			"dev": true,
 			"requires": {
-				"core-assert": "0.2.1"
+				"core-assert": "^0.2.0"
 			}
 		},
 		"define-property": {
@@ -1952,8 +1952,8 @@
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -1961,7 +1961,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1969,7 +1969,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1977,9 +1977,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"isobject": {
@@ -1999,12 +1999,12 @@
 			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
 			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 			"requires": {
-				"globby": "6.1.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.1",
-				"p-map": "1.2.0",
-				"pify": "3.0.0",
-				"rimraf": "2.6.2"
+				"globby": "^6.1.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"p-map": "^1.1.1",
+				"pify": "^3.0.0",
+				"rimraf": "^2.2.8"
 			},
 			"dependencies": {
 				"globby": {
@@ -2012,11 +2012,11 @@
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -2036,7 +2036,7 @@
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				}
 			}
@@ -2052,7 +2052,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"dir-glob": {
@@ -2060,8 +2060,8 @@
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 			"requires": {
-				"arrify": "1.0.1",
-				"path-type": "3.0.0"
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
 			}
 		},
 		"doctrine": {
@@ -2070,8 +2070,13 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2"
+				"esutils": "^2.0.2"
 			}
+		},
+		"dom-to-image": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
+			"integrity": "sha1-ilA2CAiMh7HCL5A0rgMuGJiVWGc="
 		},
 		"dom-walk": {
 			"version": "0.1.1",
@@ -2084,7 +2089,7 @@
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"duplexer3": {
@@ -2105,7 +2110,7 @@
 			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
-				"core-js": "2.5.7"
+				"core-js": "^2.0.0"
 			}
 		},
 		"enhance-visitors": {
@@ -2114,7 +2119,7 @@
 			"integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.13.1"
 			}
 		},
 		"env-editor": {
@@ -2134,7 +2139,7 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es6-error": {
@@ -2153,7 +2158,7 @@
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
-				"es6-promise": "4.2.4"
+				"es6-promise": "^4.0.3"
 			}
 		},
 		"escape-string-regexp": {
@@ -2167,44 +2172,44 @@
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"babel-code-frame": "6.26.0",
-				"chalk": "2.4.1",
-				"concat-stream": "1.6.2",
-				"cross-spawn": "5.1.0",
-				"debug": "3.1.0",
-				"doctrine": "2.1.0",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "1.0.0",
-				"espree": "3.5.4",
-				"esquery": "1.0.1",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"functional-red-black-tree": "1.0.1",
-				"glob": "7.1.2",
-				"globals": "11.7.0",
-				"ignore": "3.3.10",
-				"imurmurhash": "0.1.4",
-				"inquirer": "3.3.0",
-				"is-resolvable": "1.1.0",
-				"js-yaml": "3.12.0",
-				"json-stable-stringify-without-jsonify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "7.0.0",
-				"progress": "2.0.0",
-				"regexpp": "1.1.0",
-				"require-uncached": "1.0.3",
-				"semver": "5.5.0",
-				"strip-ansi": "4.0.0",
-				"strip-json-comments": "2.0.1",
+				"ajv": "^5.3.0",
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.1.0",
+				"concat-stream": "^1.6.0",
+				"cross-spawn": "^5.1.0",
+				"debug": "^3.1.0",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.4",
+				"esquery": "^1.0.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.0.1",
+				"ignore": "^3.3.3",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^3.0.6",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.9.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^1.0.1",
+				"require-uncached": "^1.0.3",
+				"semver": "^5.3.0",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "~2.0.1",
 				"table": "4.0.2",
-				"text-table": "0.2.0"
+				"text-table": "~0.2.0"
 			},
 			"dependencies": {
 				"chardet": {
@@ -2219,9 +2224,9 @@
 					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 					"dev": true,
 					"requires": {
-						"chardet": "0.4.2",
-						"iconv-lite": "0.4.23",
-						"tmp": "0.0.33"
+						"chardet": "^0.4.0",
+						"iconv-lite": "^0.4.17",
+						"tmp": "^0.0.33"
 					}
 				},
 				"globals": {
@@ -2236,20 +2241,20 @@
 					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
-						"cli-cursor": "2.1.0",
-						"cli-width": "2.2.0",
-						"external-editor": "2.2.0",
-						"figures": "2.0.0",
-						"lodash": "4.17.10",
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.4",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
 						"mute-stream": "0.0.7",
-						"run-async": "2.3.0",
-						"rx-lite": "4.0.8",
-						"rx-lite-aggregates": "4.0.8",
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"through": "2.3.8"
+						"run-async": "^2.2.0",
+						"rx-lite": "^4.0.8",
+						"rx-lite-aggregates": "^4.0.8",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
 					}
 				}
 			}
@@ -2260,8 +2265,8 @@
 			"integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
 			"dev": true,
 			"requires": {
-				"lodash.get": "4.4.2",
-				"lodash.zip": "4.2.0"
+				"lodash.get": "^4.4.2",
+				"lodash.zip": "^4.2.0"
 			}
 		},
 		"eslint-config-prettier": {
@@ -2270,7 +2275,7 @@
 			"integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
 			"dev": true,
 			"requires": {
-				"get-stdin": "5.0.1"
+				"get-stdin": "^5.0.1"
 			},
 			"dependencies": {
 				"get-stdin": {
@@ -2293,11 +2298,11 @@
 			"integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "2.0.0",
-				"chalk": "2.4.1",
-				"log-symbols": "2.2.0",
-				"plur": "2.1.2",
-				"string-width": "2.1.1"
+				"ansi-escapes": "^2.0.0",
+				"chalk": "^2.1.0",
+				"log-symbols": "^2.0.0",
+				"plur": "^2.1.2",
+				"string-width": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -2314,8 +2319,8 @@
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"resolve": "1.8.1"
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2341,8 +2346,8 @@
 			"integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"pkg-dir": "1.0.0"
+				"debug": "^2.6.8",
+				"pkg-dir": "^1.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2360,8 +2365,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"ms": {
@@ -2376,7 +2381,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pinkie": {
@@ -2391,7 +2396,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -2400,7 +2405,7 @@
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2"
+						"find-up": "^1.0.0"
 					}
 				}
 			}
@@ -2411,14 +2416,14 @@
 			"integrity": "sha512-V0+QZkTYoEXAp8fojaoD85orqNgGfyHWpwQEUqVIRGCRsX9BFnKbG2eX875NgciF3Aouq7smOZcLYqQKgAyH7w==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"deep-strict-equal": "0.2.0",
-				"enhance-visitors": "1.0.0",
-				"espree": "3.5.4",
-				"espurify": "1.8.0",
-				"import-modules": "1.1.0",
-				"multimatch": "2.1.0",
-				"pkg-up": "2.0.0"
+				"arrify": "^1.0.1",
+				"deep-strict-equal": "^0.2.0",
+				"enhance-visitors": "^1.0.0",
+				"espree": "^3.1.3",
+				"espurify": "^1.5.0",
+				"import-modules": "^1.1.0",
+				"multimatch": "^2.1.0",
+				"pkg-up": "^2.0.0"
 			}
 		},
 		"eslint-plugin-import": {
@@ -2427,16 +2432,16 @@
 			"integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
 			"dev": true,
 			"requires": {
-				"contains-path": "0.1.0",
-				"debug": "2.6.9",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.8",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "0.3.2",
-				"eslint-module-utils": "2.2.0",
-				"has": "1.0.3",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"read-pkg-up": "2.0.0",
-				"resolve": "1.8.1"
+				"eslint-import-resolver-node": "^0.3.1",
+				"eslint-module-utils": "^2.2.0",
+				"has": "^1.0.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.3",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.6.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -2454,8 +2459,8 @@
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"dev": true,
 					"requires": {
-						"esutils": "2.0.2",
-						"isarray": "1.0.0"
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -2464,10 +2469,10 @@
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"ms": {
@@ -2482,7 +2487,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.2"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"path-type": {
@@ -2491,7 +2496,7 @@
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"dev": true,
 					"requires": {
-						"pify": "2.3.0"
+						"pify": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -2506,9 +2511,9 @@
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2517,8 +2522,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "2.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
 					}
 				}
 			}
@@ -2529,10 +2534,10 @@
 			"integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
 			"dev": true,
 			"requires": {
-				"is-get-set-prop": "1.0.0",
-				"is-js-type": "2.0.0",
-				"is-obj-prop": "1.0.0",
-				"is-proto-prop": "1.0.1"
+				"is-get-set-prop": "^1.0.0",
+				"is-js-type": "^2.0.0",
+				"is-obj-prop": "^1.0.0",
+				"is-proto-prop": "^1.0.0"
 			}
 		},
 		"eslint-plugin-node": {
@@ -2541,10 +2546,10 @@
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
 			"dev": true,
 			"requires": {
-				"ignore": "3.3.10",
-				"minimatch": "3.0.4",
-				"resolve": "1.8.1",
-				"semver": "5.5.0"
+				"ignore": "^3.3.6",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.3",
+				"semver": "^5.4.1"
 			}
 		},
 		"eslint-plugin-prettier": {
@@ -2553,8 +2558,8 @@
 			"integrity": "sha512-wNZ2z0oVCWnf+3BSI7roS+z4gGu2AwcPKUek+SlLZMZg+X0KbZLsB2knul7fd0K3iuIp402HIYzm4f2+OyfXxA==",
 			"dev": true,
 			"requires": {
-				"fast-diff": "1.1.2",
-				"jest-docblock": "21.2.0"
+				"fast-diff": "^1.1.1",
+				"jest-docblock": "^21.0.0"
 			}
 		},
 		"eslint-plugin-promise": {
@@ -2569,14 +2574,14 @@
 			"integrity": "sha512-F1JMyd42hx4qGhIaVdOSbDyhcxPgTy4BOzctTCkV+hqebPBUOAQn1f5AhMK2LTyiqCmKiTs8huAErbLBSWKoCQ==",
 			"dev": true,
 			"requires": {
-				"clean-regexp": "1.0.0",
-				"eslint-ast-utils": "1.1.0",
-				"import-modules": "1.1.0",
-				"lodash.camelcase": "4.3.0",
-				"lodash.kebabcase": "4.1.1",
-				"lodash.snakecase": "4.1.1",
-				"lodash.upperfirst": "4.3.1",
-				"safe-regex": "1.1.0"
+				"clean-regexp": "^1.0.0",
+				"eslint-ast-utils": "^1.0.0",
+				"import-modules": "^1.1.0",
+				"lodash.camelcase": "^4.1.1",
+				"lodash.kebabcase": "^4.0.1",
+				"lodash.snakecase": "^4.0.1",
+				"lodash.upperfirst": "^4.2.0",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"eslint-scope": {
@@ -2585,8 +2590,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.1",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -2601,10 +2606,10 @@
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
 			"dev": true,
 			"requires": {
-				"is-url": "1.2.4",
-				"path-is-absolute": "1.0.1",
-				"source-map": "0.5.7",
-				"xtend": "4.0.1"
+				"is-url": "^1.2.1",
+				"path-is-absolute": "^1.0.0",
+				"source-map": "^0.5.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"espree": {
@@ -2613,8 +2618,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.7.1",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
 			}
 		},
 		"esprima": {
@@ -2629,7 +2634,7 @@
 			"integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.7"
+				"core-js": "^2.0.0"
 			}
 		},
 		"esquery": {
@@ -2638,7 +2643,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -2647,7 +2652,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -2668,13 +2673,13 @@
 			"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "6.0.5",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -2683,11 +2688,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "1.0.4",
-						"path-key": "2.0.1",
-						"semver": "5.5.0",
-						"shebang-command": "1.2.0",
-						"which": "1.3.1"
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				}
 			}
@@ -2708,7 +2713,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -2717,7 +2722,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.4"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"extend-shallow": {
@@ -2725,8 +2730,8 @@
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -2734,7 +2739,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -2744,9 +2749,9 @@
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.0.tgz",
 			"integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
 			"requires": {
-				"chardet": "0.5.0",
-				"iconv-lite": "0.4.23",
-				"tmp": "0.0.33"
+				"chardet": "^0.5.0",
+				"iconv-lite": "^0.4.22",
+				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -2755,7 +2760,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extract-zip": {
@@ -2801,12 +2806,12 @@
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
 			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
 			"requires": {
-				"@mrmlnc/readdir-enhanced": "2.2.1",
-				"@nodelib/fs.stat": "1.1.0",
-				"glob-parent": "3.1.0",
-				"is-glob": "4.0.0",
-				"merge2": "1.2.2",
-				"micromatch": "3.1.10"
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.0.1",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.1",
+				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -2824,16 +2829,16 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2841,7 +2846,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2859,13 +2864,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2873,7 +2878,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -2881,7 +2886,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -2889,7 +2894,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -2897,7 +2902,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2907,7 +2912,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -2915,7 +2920,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -2925,9 +2930,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -2942,14 +2947,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -2957,7 +2962,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -2965,7 +2970,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2975,10 +2980,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2986,7 +2991,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -2996,8 +3001,8 @@
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -3005,7 +3010,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						}
 					}
@@ -3015,7 +3020,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -3023,7 +3028,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -3031,9 +3036,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-extglob": {
@@ -3046,7 +3051,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -3054,7 +3059,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3062,7 +3067,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -3082,19 +3087,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.13",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"ms": {
@@ -3121,7 +3126,7 @@
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"requires": {
-				"pend": "1.2.0"
+				"pend": "~1.2.0"
 			}
 		},
 		"figures": {
@@ -3129,7 +3134,7 @@
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -3138,8 +3143,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"file-extension": {
@@ -3164,11 +3169,11 @@
 			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "3.0.0",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"find-cache-dir": {
@@ -3177,9 +3182,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"make-dir": "1.3.0",
-				"pkg-dir": "2.0.0"
+				"commondir": "^1.0.1",
+				"make-dir": "^1.0.0",
+				"pkg-dir": "^2.0.0"
 			}
 		},
 		"find-up": {
@@ -3187,7 +3192,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -3196,10 +3201,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"del": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"write": "^0.2.1"
 			},
 			"dependencies": {
 				"del": {
@@ -3208,13 +3213,13 @@
 					"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 					"dev": true,
 					"requires": {
-						"globby": "5.0.0",
-						"is-path-cwd": "1.0.0",
-						"is-path-in-cwd": "1.0.1",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"rimraf": "2.6.2"
+						"globby": "^5.0.0",
+						"is-path-cwd": "^1.0.0",
+						"is-path-in-cwd": "^1.0.0",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
 				"globby": {
@@ -3223,12 +3228,12 @@
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"arrify": "1.0.1",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"arrify": "^1.0.0",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -3249,7 +3254,7 @@
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				}
 			}
@@ -3265,7 +3270,7 @@
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
 			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
 			"requires": {
-				"is-callable": "1.1.4"
+				"is-callable": "^1.1.3"
 			}
 		},
 		"for-in": {
@@ -3279,7 +3284,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"fragment-cache": {
@@ -3287,7 +3292,7 @@
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fs.realpath": {
@@ -3302,8 +3307,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.10.0",
-				"node-pre-gyp": "0.10.0"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3329,8 +3334,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"balanced-match": {
@@ -3343,7 +3348,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -3407,7 +3412,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
@@ -3422,14 +3427,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
@@ -3438,12 +3443,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
@@ -3458,7 +3463,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": "^2.1.0"
 					}
 				},
 				"ignore-walk": {
@@ -3467,7 +3472,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "3.0.4"
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
@@ -3476,8 +3481,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -3496,7 +3501,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
@@ -3510,7 +3515,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -3523,8 +3528,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
@@ -3533,7 +3538,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"mkdirp": {
@@ -3556,9 +3561,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -3567,16 +3572,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
@@ -3585,8 +3590,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
 				"npm-bundled": {
@@ -3601,8 +3606,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
 					}
 				},
 				"npmlog": {
@@ -3611,10 +3616,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -3633,7 +3638,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -3654,8 +3659,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -3676,10 +3681,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.5.1",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -3696,13 +3701,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
@@ -3711,7 +3716,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -3754,9 +3759,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -3765,7 +3770,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -3773,7 +3778,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -3788,13 +3793,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -3809,7 +3814,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
@@ -3876,12 +3881,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -3890,8 +3895,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-parent": {
@@ -3900,7 +3905,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-to-regexp": {
@@ -3913,8 +3918,8 @@
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
 			"requires": {
-				"min-document": "2.19.0",
-				"process": "0.5.2"
+				"min-document": "^2.19.0",
+				"process": "~0.5.1"
 			}
 		},
 		"global-dirs": {
@@ -3923,7 +3928,7 @@
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 			"dev": true,
 			"requires": {
-				"ini": "1.3.5"
+				"ini": "^1.3.4"
 			}
 		},
 		"globals": {
@@ -3937,13 +3942,13 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
 			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 			"requires": {
-				"array-union": "1.0.2",
-				"dir-glob": "2.0.0",
-				"fast-glob": "2.2.2",
-				"glob": "7.1.2",
-				"ignore": "3.3.10",
-				"pify": "3.0.0",
-				"slash": "1.0.0"
+				"array-union": "^1.0.1",
+				"dir-glob": "^2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
 			}
 		},
 		"got": {
@@ -3952,17 +3957,17 @@
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
-				"create-error-class": "3.0.2",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-redirect": "1.0.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.1",
-				"safe-buffer": "5.1.2",
-				"timed-out": "4.0.1",
-				"unzip-response": "2.0.1",
-				"url-parse-lax": "1.0.0"
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -3976,7 +3981,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -3984,7 +3989,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-color": {
@@ -4004,9 +4009,9 @@
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4021,8 +4026,8 @@
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -4030,7 +4035,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4038,7 +4043,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4048,7 +4053,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -4065,8 +4070,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -4079,10 +4084,10 @@
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
-				"depd": "1.1.2",
+				"depd": "~1.1.2",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.1.0",
-				"statuses": "1.5.0"
+				"statuses": ">= 1.4.0 < 2"
 			}
 		},
 		"https-proxy-agent": {
@@ -4090,8 +4095,8 @@
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
 			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
 			"requires": {
-				"agent-base": "4.2.1",
-				"debug": "3.1.0"
+				"agent-base": "^4.1.0",
+				"debug": "^3.1.0"
 			}
 		},
 		"hullabaloo-config-manager": {
@@ -4100,20 +4105,20 @@
 			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "4.2.0",
-				"es6-error": "4.1.1",
-				"graceful-fs": "4.1.11",
-				"indent-string": "3.2.0",
-				"json5": "0.5.1",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.clonedeepwith": "4.5.0",
-				"lodash.isequal": "4.5.0",
-				"lodash.merge": "4.6.1",
-				"md5-hex": "2.0.0",
-				"package-hash": "2.0.0",
-				"pkg-dir": "2.0.0",
-				"resolve-from": "3.0.0",
-				"safe-buffer": "5.1.2"
+				"dot-prop": "^4.1.0",
+				"es6-error": "^4.0.2",
+				"graceful-fs": "^4.1.11",
+				"indent-string": "^3.1.0",
+				"json5": "^0.5.1",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.clonedeepwith": "^4.5.0",
+				"lodash.isequal": "^4.5.0",
+				"lodash.merge": "^4.6.0",
+				"md5-hex": "^2.0.0",
+				"package-hash": "^2.0.0",
+				"pkg-dir": "^2.0.0",
+				"resolve-from": "^3.0.0",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"iconv-lite": {
@@ -4121,7 +4126,7 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
 			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"ignore": {
@@ -4147,8 +4152,8 @@
 			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			}
 		},
 		"import-modules": {
@@ -4173,8 +4178,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -4193,19 +4198,19 @@
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.0.0.tgz",
 			"integrity": "sha512-tISQWRwtcAgrz+SHPhTH7d3e73k31gsOy6i1csonLc0u1dVK/wYvuOnFeiWqC5OXFIYbmrIFInef31wbT8MEJg==",
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.4.1",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "3.0.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.10",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.0",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rxjs": "6.2.1",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rxjs": "^6.1.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			}
 		},
 		"invariant": {
@@ -4214,7 +4219,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"irregular-plurals": {
@@ -4228,7 +4233,7 @@
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-arrayish": {
@@ -4242,7 +4247,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "1.11.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -4255,7 +4260,7 @@
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -4269,7 +4274,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.1.3"
+				"ci-info": "^1.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -4277,7 +4282,7 @@
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-descriptor": {
@@ -4285,9 +4290,9 @@
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4309,7 +4314,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-error": {
@@ -4334,7 +4339,7 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4359,8 +4364,8 @@
 			"integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
 			"dev": true,
 			"requires": {
-				"get-set-props": "0.1.0",
-				"lowercase-keys": "1.0.1"
+				"get-set-props": "^0.1.0",
+				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"is-glob": {
@@ -4369,7 +4374,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-installed-globally": {
@@ -4378,8 +4383,8 @@
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 			"dev": true,
 			"requires": {
-				"global-dirs": "0.1.1",
-				"is-path-inside": "1.0.1"
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-js-type": {
@@ -4388,7 +4393,7 @@
 			"integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
 			"dev": true,
 			"requires": {
-				"js-types": "1.0.0"
+				"js-types": "^1.0.0"
 			}
 		},
 		"is-npm": {
@@ -4403,7 +4408,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-obj": {
@@ -4418,8 +4423,8 @@
 			"integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "1.0.1",
-				"obj-props": "1.1.0"
+				"lowercase-keys": "^1.0.0",
+				"obj-props": "^1.0.0"
 			}
 		},
 		"is-observable": {
@@ -4427,7 +4432,7 @@
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
 			"requires": {
-				"symbol-observable": "1.2.0"
+				"symbol-observable": "^1.1.0"
 			}
 		},
 		"is-path-cwd": {
@@ -4440,7 +4445,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
 			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"requires": {
-				"is-path-inside": "1.0.1"
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-path-inside": {
@@ -4448,7 +4453,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
 			}
 		},
 		"is-plain-obj": {
@@ -4461,7 +4466,7 @@
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4494,8 +4499,8 @@
 			"integrity": "sha512-dkmgrJB7nfJhH1ySK1/Qn9xLPMv3ZNlPSAPoyUseD6DQzBF6YmbgQnoyy9OM8derNUlDVJlUGdCEhYbcCPfN5A==",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "1.0.1",
-				"proto-props": "1.1.0"
+				"lowercase-keys": "^1.0.0",
+				"proto-props": "^1.1.0"
 			}
 		},
 		"is-redirect": {
@@ -4567,8 +4572,8 @@
 			"resolved": "https://registry.npmjs.org/iterm2-version/-/iterm2-version-2.3.0.tgz",
 			"integrity": "sha1-rmQABGHgK18f5TMfC58Oxxzg4Tg=",
 			"requires": {
-				"app-path": "2.2.0",
-				"plist": "2.1.0"
+				"app-path": "^2.1.0",
+				"plist": "^2.0.1"
 			}
 		},
 		"jest-docblock": {
@@ -4583,7 +4588,8 @@
 			"integrity": "sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII="
 		},
 		"jpgjs": {
-			"version": "github:notmasteryet/jpgjs#f1d30922fda93417669246f5a25cf2393dd9c108"
+			"version": "github:notmasteryet/jpgjs#f1d30922fda93417669246f5a25cf2393dd9c108",
+			"from": "jpgjs@github:notmasteryet/jpgjs#f1d30922fda93417669246f5a25cf2393dd9c108"
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
@@ -4609,8 +4615,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsesc": {
@@ -4647,7 +4653,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"last-line-stream": {
@@ -4656,7 +4662,7 @@
 			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
 			"dev": true,
 			"requires": {
-				"through2": "2.0.3"
+				"through2": "^2.0.0"
 			}
 		},
 		"latest-version": {
@@ -4665,7 +4671,7 @@
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 			"dev": true,
 			"requires": {
-				"package-json": "4.0.1"
+				"package-json": "^4.0.0"
 			}
 		},
 		"levn": {
@@ -4674,8 +4680,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"line-column-path": {
@@ -4689,22 +4695,22 @@
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.1.tgz",
 			"integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
 			"requires": {
-				"@samverschueren/stream-to-observable": "0.3.0",
-				"cli-truncate": "0.2.1",
-				"figures": "1.7.0",
-				"indent-string": "2.1.0",
-				"is-observable": "1.1.0",
-				"is-promise": "2.1.0",
-				"is-stream": "1.1.0",
-				"listr-silent-renderer": "1.1.1",
-				"listr-update-renderer": "0.4.0",
-				"listr-verbose-renderer": "0.4.1",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"ora": "0.2.3",
-				"p-map": "1.2.0",
-				"rxjs": "6.2.1",
-				"strip-ansi": "3.0.1"
+				"@samverschueren/stream-to-observable": "^0.3.0",
+				"cli-truncate": "^0.2.1",
+				"figures": "^1.7.0",
+				"indent-string": "^2.1.0",
+				"is-observable": "^1.1.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.4.0",
+				"listr-verbose-renderer": "^0.4.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"ora": "^0.2.3",
+				"p-map": "^1.1.1",
+				"rxjs": "^6.1.0",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4717,11 +4723,11 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"cli-truncate": {
@@ -4730,7 +4736,7 @@
 					"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
 					"requires": {
 						"slice-ansi": "0.0.4",
-						"string-width": "1.0.2"
+						"string-width": "^1.0.1"
 					}
 				},
 				"figures": {
@@ -4738,8 +4744,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"indent-string": {
@@ -4747,7 +4753,7 @@
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -4755,7 +4761,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"log-symbols": {
@@ -4763,7 +4769,7 @@
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				},
 				"slice-ansi": {
@@ -4776,9 +4782,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4786,7 +4792,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -4806,14 +4812,14 @@
 			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"elegant-spinner": "1.0.1",
-				"figures": "1.7.0",
-				"indent-string": "3.2.0",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4826,11 +4832,11 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"cli-truncate": {
@@ -4839,7 +4845,7 @@
 					"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
 					"requires": {
 						"slice-ansi": "0.0.4",
-						"string-width": "1.0.2"
+						"string-width": "^1.0.1"
 					}
 				},
 				"figures": {
@@ -4847,8 +4853,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -4856,7 +4862,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"log-symbols": {
@@ -4864,7 +4870,7 @@
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				},
 				"slice-ansi": {
@@ -4877,9 +4883,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4887,7 +4893,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -4902,10 +4908,10 @@
 			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"date-fns": "1.29.0",
-				"figures": "1.7.0"
+				"chalk": "^1.1.3",
+				"cli-cursor": "^1.0.2",
+				"date-fns": "^1.27.2",
+				"figures": "^1.7.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4918,11 +4924,11 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"cli-cursor": {
@@ -4930,7 +4936,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"figures": {
@@ -4938,8 +4944,8 @@
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"onetime": {
@@ -4952,8 +4958,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4961,7 +4967,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -4977,12 +4983,12 @@
 			"integrity": "sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=",
 			"requires": {
 				"buffer-equal": "0.0.1",
-				"mime": "1.6.0",
-				"parse-bmfont-ascii": "1.0.6",
-				"parse-bmfont-binary": "1.0.6",
-				"parse-bmfont-xml": "1.1.3",
-				"xhr": "2.5.0",
-				"xtend": "4.0.1"
+				"mime": "^1.3.4",
+				"parse-bmfont-ascii": "^1.0.3",
+				"parse-bmfont-binary": "^1.0.5",
+				"parse-bmfont-xml": "^1.1.0",
+				"xhr": "^2.0.1",
+				"xtend": "^4.0.0"
 			},
 			"dependencies": {
 				"mime": {
@@ -4997,10 +5003,10 @@
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "4.0.0",
-				"pify": "3.0.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
@@ -5008,8 +5014,8 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -5113,7 +5119,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1"
+				"chalk": "^2.0.1"
 			}
 		},
 		"log-update": {
@@ -5121,8 +5127,8 @@
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"cli-cursor": "1.0.2"
+				"ansi-escapes": "^1.0.0",
+				"cli-cursor": "^1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -5135,7 +5141,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
@@ -5148,8 +5154,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -5160,7 +5166,7 @@
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"dev": true,
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -5168,8 +5174,8 @@
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
@@ -5183,8 +5189,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"make-dir": {
@@ -5193,7 +5199,7 @@
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"map-cache": {
@@ -5211,7 +5217,7 @@
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
 		},
 		"matcher": {
@@ -5220,7 +5226,7 @@
 			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.4"
 			}
 		},
 		"math-random": {
@@ -5235,7 +5241,7 @@
 			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
 			"dev": true,
 			"requires": {
-				"md5-o-matic": "0.1.1"
+				"md5-o-matic": "^0.1.1"
 			}
 		},
 		"md5-o-matic": {
@@ -5249,15 +5255,15 @@
 			"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
 			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
 			"requires": {
-				"camelcase-keys": "4.2.0",
-				"decamelize-keys": "1.1.0",
-				"loud-rejection": "1.6.0",
-				"minimist-options": "3.0.2",
-				"normalize-package-data": "2.4.0",
-				"read-pkg-up": "3.0.0",
-				"redent": "2.0.0",
-				"trim-newlines": "2.0.0",
-				"yargs-parser": "10.1.0"
+				"camelcase-keys": "^4.0.0",
+				"decamelize-keys": "^1.0.0",
+				"loud-rejection": "^1.0.0",
+				"minimist-options": "^3.0.1",
+				"normalize-package-data": "^2.3.4",
+				"read-pkg-up": "^3.0.0",
+				"redent": "^2.0.0",
+				"trim-newlines": "^2.0.0",
+				"yargs-parser": "^10.0.0"
 			}
 		},
 		"merge2": {
@@ -5271,19 +5277,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"mime": {
@@ -5301,7 +5307,7 @@
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
 			"requires": {
-				"dom-walk": "0.1.1"
+				"dom-walk": "^0.1.0"
 			}
 		},
 		"minimatch": {
@@ -5309,7 +5315,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -5322,8 +5328,8 @@
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"requires": {
-				"arrify": "1.0.1",
-				"is-plain-obj": "1.1.0"
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
 			}
 		},
 		"mixin-deep": {
@@ -5331,8 +5337,8 @@
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5340,7 +5346,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -5365,10 +5371,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			}
 		},
 		"mute-stream": {
@@ -5388,17 +5394,17 @@
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -5435,10 +5441,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.6.1",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.3"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -5447,7 +5453,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -5456,7 +5462,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -5480,9 +5486,9 @@
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5490,7 +5496,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -5500,7 +5506,7 @@
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -5516,8 +5522,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -5525,7 +5531,7 @@
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -5541,8 +5547,8 @@
 			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
 			"dev": true,
 			"requires": {
-				"is-observable": "0.2.0",
-				"symbol-observable": "1.2.0"
+				"is-observable": "^0.2.0",
+				"symbol-observable": "^1.0.4"
 			},
 			"dependencies": {
 				"is-observable": {
@@ -5551,7 +5557,7 @@
 					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 					"dev": true,
 					"requires": {
-						"symbol-observable": "0.2.4"
+						"symbol-observable": "^0.2.2"
 					},
 					"dependencies": {
 						"symbol-observable": {
@@ -5569,7 +5575,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -5577,7 +5583,7 @@
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"open-editor": {
@@ -5586,9 +5592,9 @@
 			"integrity": "sha1-dcoj8LdNSz9V7guKTg9cIyXrd18=",
 			"dev": true,
 			"requires": {
-				"env-editor": "0.3.1",
-				"line-column-path": "1.0.0",
-				"opn": "5.3.0"
+				"env-editor": "^0.3.1",
+				"line-column-path": "^1.0.0",
+				"opn": "^5.0.0"
 			}
 		},
 		"opn": {
@@ -5596,7 +5602,7 @@
 			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
 			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
 			"requires": {
-				"is-wsl": "1.1.0"
+				"is-wsl": "^1.1.0"
 			}
 		},
 		"option-chain": {
@@ -5611,12 +5617,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			}
 		},
 		"ora": {
@@ -5624,10 +5630,10 @@
 			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-spinners": "0.1.2",
-				"object-assign": "4.1.1"
+				"chalk": "^1.1.1",
+				"cli-cursor": "^1.0.2",
+				"cli-spinners": "^0.1.2",
+				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5640,11 +5646,11 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"cli-cursor": {
@@ -5652,7 +5658,7 @@
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"cli-spinners": {
@@ -5670,8 +5676,8 @@
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -5679,7 +5685,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -5711,7 +5717,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -5719,7 +5725,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "1.3.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -5738,10 +5744,10 @@
 			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"lodash.flattendeep": "4.4.0",
-				"md5-hex": "2.0.0",
-				"release-zalgo": "1.0.0"
+				"graceful-fs": "^4.1.11",
+				"lodash.flattendeep": "^4.4.0",
+				"md5-hex": "^2.0.0",
+				"release-zalgo": "^1.0.0"
 			}
 		},
 		"package-json": {
@@ -5750,10 +5756,10 @@
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"dev": true,
 			"requires": {
-				"got": "6.7.1",
-				"registry-auth-token": "3.3.2",
-				"registry-url": "3.1.0",
-				"semver": "5.5.0"
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
 			}
 		},
 		"pako": {
@@ -5776,8 +5782,8 @@
 			"resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz",
 			"integrity": "sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=",
 			"requires": {
-				"xml-parse-from-string": "1.0.1",
-				"xml2js": "0.4.19"
+				"xml-parse-from-string": "^1.0.0",
+				"xml2js": "^0.4.5"
 			}
 		},
 		"parse-glob": {
@@ -5786,10 +5792,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-headers": {
@@ -5797,7 +5803,7 @@
 			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
 			"integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
 			"requires": {
-				"for-each": "0.3.3",
+				"for-each": "^0.3.2",
 				"trim": "0.0.1"
 			}
 		},
@@ -5806,8 +5812,8 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"requires": {
-				"error-ex": "1.3.2",
-				"json-parse-better-errors": "1.0.2"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parse-ms": {
@@ -5858,7 +5864,7 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"pend": {
@@ -5883,7 +5889,7 @@
 			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
 			"dev": true,
 			"requires": {
-				"pinkie": "1.0.0"
+				"pinkie": "^1.0.0"
 			}
 		},
 		"pixelmatch": {
@@ -5891,7 +5897,7 @@
 			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
 			"integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
 			"requires": {
-				"pngjs": "3.3.3"
+				"pngjs": "^3.0.0"
 			}
 		},
 		"pkg-conf": {
@@ -5900,8 +5906,8 @@
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"load-json-file": "4.0.0"
+				"find-up": "^2.0.0",
+				"load-json-file": "^4.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -5910,7 +5916,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			}
 		},
 		"pkg-up": {
@@ -5919,7 +5925,7 @@
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			}
 		},
 		"plist": {
@@ -5929,7 +5935,7 @@
 			"requires": {
 				"base64-js": "1.2.0",
 				"xmlbuilder": "8.2.2",
-				"xmldom": "0.1.27"
+				"xmldom": "0.1.x"
 			},
 			"dependencies": {
 				"xmlbuilder": {
@@ -5945,7 +5951,7 @@
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "1.4.0"
+				"irregular-plurals": "^1.0.0"
 			}
 		},
 		"pluralize": {
@@ -5994,7 +6000,7 @@
 			"integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
 			"dev": true,
 			"requires": {
-				"parse-ms": "1.0.1"
+				"parse-ms": "^1.0.0"
 			},
 			"dependencies": {
 				"parse-ms": {
@@ -6047,14 +6053,14 @@
 			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.5.0.tgz",
 			"integrity": "sha512-eELwFtFxL+uhmg4jPZOZXzSrPEYy4CaYQNbcchBbfxY+KjMpnv6XGf/aYWaQG49OTpfi2/DMziXtDM8XuJgoUA==",
 			"requires": {
-				"debug": "3.1.0",
-				"extract-zip": "1.6.7",
-				"https-proxy-agent": "2.2.1",
-				"mime": "2.3.1",
-				"progress": "2.0.0",
-				"proxy-from-env": "1.0.0",
-				"rimraf": "2.6.2",
-				"ws": "5.2.1"
+				"debug": "^3.1.0",
+				"extract-zip": "^1.6.6",
+				"https-proxy-agent": "^2.2.1",
+				"mime": "^2.0.3",
+				"progress": "^2.0.0",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^2.6.1",
+				"ws": "^5.1.1"
 			}
 		},
 		"query-string": {
@@ -6062,8 +6068,8 @@
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-6.1.0.tgz",
 			"integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
 			"requires": {
-				"decode-uri-component": "0.2.0",
-				"strict-uri-encode": "2.0.0"
+				"decode-uri-component": "^0.2.0",
+				"strict-uri-encode": "^2.0.0"
 			}
 		},
 		"quick-lru": {
@@ -6077,9 +6083,9 @@
 			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"dev": true,
 			"requires": {
-				"is-number": "4.0.0",
-				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6113,10 +6119,10 @@
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
 			"requires": {
-				"deep-extend": "0.6.0",
-				"ini": "1.3.5",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -6132,9 +6138,9 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"requires": {
-				"load-json-file": "4.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "3.0.0"
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -6142,8 +6148,8 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "3.0.0"
+				"find-up": "^2.0.0",
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -6151,13 +6157,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -6166,10 +6172,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.6",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"redent": {
@@ -6177,8 +6183,8 @@
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 			"requires": {
-				"indent-string": "3.2.0",
-				"strip-indent": "2.0.0"
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"regenerate": {
@@ -6199,7 +6205,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -6207,8 +6213,8 @@
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpp": {
@@ -6223,9 +6229,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.4.0",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"registry-auth-token": {
@@ -6234,8 +6240,8 @@
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.8",
-				"safe-buffer": "5.1.2"
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"registry-url": {
@@ -6244,7 +6250,7 @@
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.8"
+				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
@@ -6259,7 +6265,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			}
 		},
 		"release-zalgo": {
@@ -6268,7 +6274,7 @@
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
 			"dev": true,
 			"requires": {
-				"es6-error": "4.1.1"
+				"es6-error": "^4.0.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -6292,7 +6298,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"require-precompiled": {
@@ -6307,8 +6313,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -6325,7 +6331,7 @@
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -6334,7 +6340,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -6353,8 +6359,8 @@
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
@@ -6367,7 +6373,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"run-async": {
@@ -6375,7 +6381,7 @@
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -6390,7 +6396,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"rxjs": {
@@ -6398,7 +6404,7 @@
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
 			"integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.9.0"
 			}
 		},
 		"safe-buffer": {
@@ -6411,7 +6417,7 @@
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"safer-buffer": {
@@ -6435,7 +6441,7 @@
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 			"dev": true,
 			"requires": {
-				"semver": "5.5.0"
+				"semver": "^5.0.3"
 			}
 		},
 		"serialize-error": {
@@ -6455,10 +6461,10 @@
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -6466,7 +6472,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -6482,7 +6488,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -6507,7 +6513,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0"
+				"is-fullwidth-code-point": "^2.0.0"
 			}
 		},
 		"slide": {
@@ -6521,14 +6527,14 @@
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.2",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -6544,7 +6550,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -6552,7 +6558,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"ms": {
@@ -6567,9 +6573,9 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6577,7 +6583,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -6585,7 +6591,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -6593,7 +6599,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -6601,9 +6607,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"isobject": {
@@ -6623,7 +6629,7 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sort-keys": {
@@ -6632,7 +6638,7 @@
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-map": {
@@ -6645,11 +6651,11 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"requires": {
-				"atob": "2.1.1",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -6658,8 +6664,8 @@
 			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.0",
-				"source-map": "0.6.1"
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -6680,8 +6686,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -6694,8 +6700,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -6708,7 +6714,7 @@
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"sprintf-js": {
@@ -6728,8 +6734,8 @@
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6737,7 +6743,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -6757,8 +6763,8 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"string_decoder": {
@@ -6766,7 +6772,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -6774,7 +6780,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"requires": {
-				"ansi-regex": "3.0.0"
+				"ansi-regex": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6795,7 +6801,7 @@
 			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.1"
 			}
 		},
 		"strip-eof": {
@@ -6820,11 +6826,11 @@
 			"integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"indent-string": "3.2.0",
-				"js-yaml": "3.12.0",
-				"serialize-error": "2.1.0",
-				"strip-ansi": "4.0.0"
+				"arrify": "^1.0.1",
+				"indent-string": "^3.2.0",
+				"js-yaml": "^3.10.0",
+				"serialize-error": "^2.1.0",
+				"strip-ansi": "^4.0.0"
 			}
 		},
 		"supports-color": {
@@ -6832,7 +6838,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -6853,12 +6859,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
-				"chalk": "2.4.1",
-				"lodash": "4.17.10",
+				"ajv": "^5.2.3",
+				"ajv-keywords": "^2.1.0",
+				"chalk": "^2.1.0",
+				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
 			}
 		},
 		"term-img": {
@@ -6866,8 +6872,8 @@
 			"resolved": "https://registry.npmjs.org/term-img/-/term-img-2.1.0.tgz",
 			"integrity": "sha512-j78Y+26QYTTWvtVVCmDx94idvQm6p59E+xRfQDSevIyM8dg45uUAtr/xbu13l0BeKrebPyUpgh8PM3noXlIBkw==",
 			"requires": {
-				"ansi-escapes": "2.0.0",
-				"iterm2-version": "2.3.0"
+				"ansi-escapes": "^2.0.0",
+				"iterm2-version": "^2.1.0"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -6883,7 +6889,7 @@
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0"
+				"execa": "^0.7.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -6892,13 +6898,13 @@
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				}
 			}
@@ -6908,9 +6914,9 @@
 			"resolved": "https://registry.npmjs.org/terminal-image/-/terminal-image-0.1.1.tgz",
 			"integrity": "sha512-TOn21N3wisU+4IxchSIZCy7fMem5G0QJzXc3Bs/0gX0muvEmjZqiVtGtNZmJicSx4oJtX1pGiWdInGHLepSeLQ==",
 			"requires": {
-				"@sindresorhus/jimp": "0.3.0",
-				"chalk": "2.4.1",
-				"term-img": "2.1.0"
+				"@sindresorhus/jimp": "^0.3.0",
+				"chalk": "^2.4.1",
+				"term-img": "^2.1.0"
 			}
 		},
 		"text-table": {
@@ -6936,8 +6942,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"time-zone": {
@@ -6962,7 +6968,7 @@
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.2"
 			}
 		},
 		"to-fast-properties": {
@@ -6976,7 +6982,7 @@
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"to-regex": {
@@ -6984,10 +6990,10 @@
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -6995,8 +7001,8 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -7004,7 +7010,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				}
 			}
@@ -7042,7 +7048,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"typedarray": {
@@ -7061,10 +7067,10 @@
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -7072,7 +7078,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
@@ -7080,10 +7086,10 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
@@ -7094,7 +7100,7 @@
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 			"dev": true,
 			"requires": {
-				"crypto-random-string": "1.0.0"
+				"crypto-random-string": "^1.0.0"
 			}
 		},
 		"unique-temp-dir": {
@@ -7103,8 +7109,8 @@
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1",
-				"os-tmpdir": "1.0.2",
+				"mkdirp": "^0.5.1",
+				"os-tmpdir": "^1.0.1",
 				"uid2": "0.0.3"
 			}
 		},
@@ -7118,8 +7124,8 @@
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
@@ -7127,9 +7133,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -7166,16 +7172,16 @@
 			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 			"dev": true,
 			"requires": {
-				"boxen": "1.3.0",
-				"chalk": "2.4.1",
-				"configstore": "3.1.2",
-				"import-lazy": "2.1.0",
-				"is-ci": "1.1.0",
-				"is-installed-globally": "0.1.0",
-				"is-npm": "1.0.0",
-				"latest-version": "3.1.0",
-				"semver-diff": "2.1.0",
-				"xdg-basedir": "3.0.0"
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
 			}
 		},
 		"urix": {
@@ -7189,7 +7195,7 @@
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"use": {
@@ -7197,7 +7203,7 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7213,7 +7219,7 @@
 			"integrity": "sha512-Rv9/OsKlBgMlLGai2EAoVheIbdBlndMunkXH4BuU81R2+Nky24I670OdGIb+NMpCbuHGyKjk9OQ7hdyOxuNXgw==",
 			"requires": {
 				"jpgjs": "github:notmasteryet/jpgjs#f1d30922fda93417669246f5a25cf2393dd9c108",
-				"pako": "1.0.6"
+				"pako": "^1.0.5"
 			}
 		},
 		"util-deprecate": {
@@ -7226,8 +7232,8 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"well-known-symbols": {
@@ -7241,7 +7247,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"widest-line": {
@@ -7250,7 +7256,7 @@
 			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
 			}
 		},
 		"wordwrap": {
@@ -7270,7 +7276,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -7279,9 +7285,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"write-json-file": {
@@ -7290,12 +7296,12 @@
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 			"dev": true,
 			"requires": {
-				"detect-indent": "5.0.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.3.0",
-				"pify": "3.0.0",
-				"sort-keys": "2.0.0",
-				"write-file-atomic": "2.3.0"
+				"detect-indent": "^5.0.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"sort-keys": "^2.0.0",
+				"write-file-atomic": "^2.0.0"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -7312,16 +7318,16 @@
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
 			"dev": true,
 			"requires": {
-				"sort-keys": "2.0.0",
-				"write-json-file": "2.3.0"
+				"sort-keys": "^2.0.0",
+				"write-json-file": "^2.2.0"
 			}
 		},
 		"ws": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.1.tgz",
-			"integrity": "sha512-2NkHdPKjDBj3CHdnAGNpmlliryKqF+n9MYXX7/wsVC4yqYocKreKNjydPDvT3wShAZnndlM0RytEfTALCDvz7A==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 			"requires": {
-				"async-limiter": "1.0.0"
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"xdg-basedir": {
@@ -7335,10 +7341,10 @@
 			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
 			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
 			"requires": {
-				"global": "4.3.2",
-				"is-function": "1.0.1",
-				"parse-headers": "2.0.1",
-				"xtend": "4.0.1"
+				"global": "~4.3.0",
+				"is-function": "^1.0.1",
+				"parse-headers": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"xml-parse-from-string": {
@@ -7351,8 +7357,8 @@
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
 			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
 			"requires": {
-				"sax": "1.2.4",
-				"xmlbuilder": "9.0.7"
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
 			}
 		},
 		"xmlbuilder": {
@@ -7371,36 +7377,36 @@
 			"integrity": "sha512-pQp9cMptNOm3Ru8Ks4M1lQmTidYmn0kPrlkJNM3mCDMMhpQgiBzEWtekeQP/qH+rmnV7aZZv2ttaK30TjTtpEQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"debug": "3.1.0",
-				"eslint": "4.19.1",
-				"eslint-config-prettier": "2.9.0",
-				"eslint-config-xo": "0.22.2",
-				"eslint-formatter-pretty": "1.3.0",
-				"eslint-plugin-ava": "4.5.1",
-				"eslint-plugin-import": "2.13.0",
-				"eslint-plugin-no-use-extend-native": "0.3.12",
-				"eslint-plugin-node": "6.0.1",
-				"eslint-plugin-prettier": "2.6.1",
-				"eslint-plugin-promise": "3.8.0",
-				"eslint-plugin-unicorn": "4.0.3",
-				"get-stdin": "6.0.0",
-				"globby": "8.0.1",
-				"has-flag": "3.0.0",
-				"lodash.isequal": "4.5.0",
-				"lodash.mergewith": "4.6.1",
-				"meow": "5.0.0",
-				"multimatch": "2.1.0",
-				"open-editor": "1.2.0",
-				"path-exists": "3.0.0",
-				"pkg-conf": "2.1.0",
-				"prettier": "1.13.7",
-				"resolve-cwd": "2.0.0",
-				"resolve-from": "4.0.0",
-				"semver": "5.5.0",
-				"slash": "2.0.0",
-				"update-notifier": "2.5.0",
-				"xo-init": "0.7.0"
+				"arrify": "^1.0.1",
+				"debug": "^3.1.0",
+				"eslint": "^4.19.1",
+				"eslint-config-prettier": "^2.9.0",
+				"eslint-config-xo": "^0.22.0",
+				"eslint-formatter-pretty": "^1.3.0",
+				"eslint-plugin-ava": "^4.5.0",
+				"eslint-plugin-import": "^2.11.0",
+				"eslint-plugin-no-use-extend-native": "^0.3.12",
+				"eslint-plugin-node": "^6.0.0",
+				"eslint-plugin-prettier": "^2.6.0",
+				"eslint-plugin-promise": "^3.7.0",
+				"eslint-plugin-unicorn": "^4.0.3",
+				"get-stdin": "^6.0.0",
+				"globby": "^8.0.0",
+				"has-flag": "^3.0.0",
+				"lodash.isequal": "^4.5.0",
+				"lodash.mergewith": "^4.6.1",
+				"meow": "^5.0.0",
+				"multimatch": "^2.1.0",
+				"open-editor": "^1.2.0",
+				"path-exists": "^3.0.0",
+				"pkg-conf": "^2.1.0",
+				"prettier": "^1.12.1",
+				"resolve-cwd": "^2.0.0",
+				"resolve-from": "^4.0.0",
+				"semver": "^5.5.0",
+				"slash": "^2.0.0",
+				"update-notifier": "^2.3.0",
+				"xo-init": "^0.7.0"
 			},
 			"dependencies": {
 				"get-stdin": {
@@ -7415,13 +7421,13 @@
 					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"dir-glob": "2.0.0",
-						"fast-glob": "2.2.2",
-						"glob": "7.1.2",
-						"ignore": "3.3.10",
-						"pify": "3.0.0",
-						"slash": "1.0.0"
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"fast-glob": "^2.0.2",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
 					},
 					"dependencies": {
 						"slash": {
@@ -7458,14 +7464,14 @@
 			"integrity": "sha512-mrrCKMu52vz0u2tiOl8DoG709pBtnSp58bb4/j58a4jeXjrb1gV7dxfOBjOlXitYtfW2QnlxxxfAojoFcpynDg==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"execa": "0.9.0",
-				"has-yarn": "1.0.0",
-				"minimist": "1.2.0",
-				"path-exists": "3.0.0",
-				"read-pkg-up": "3.0.0",
-				"the-argv": "1.0.0",
-				"write-pkg": "3.2.0"
+				"arrify": "^1.0.0",
+				"execa": "^0.9.0",
+				"has-yarn": "^1.0.0",
+				"minimist": "^1.1.3",
+				"path-exists": "^3.0.0",
+				"read-pkg-up": "^3.0.0",
+				"the-argv": "^1.0.0",
+				"write-pkg": "^3.1.0"
 			},
 			"dependencies": {
 				"execa": {
@@ -7474,13 +7480,13 @@
 					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"minimist": {
@@ -7506,7 +7512,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
 			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			}
 		},
 		"yauzl": {
@@ -7514,7 +7520,7 @@
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
 			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
 			"requires": {
-				"fd-slicer": "1.0.1"
+				"fd-slicer": "~1.0.1"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	"dependencies": {
 		"chalk": "^2.4.1",
 		"del": "^3.0.0",
+		"dom-to-image": "^2.6.0",
 		"file-extension": "^4.0.5",
 		"globby": "^8.0.1",
 		"inquirer": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"del": "^3.0.0",
 		"dom-to-image": "^2.6.0",
 		"file-extension": "^4.0.5",
+		"fs-extra": "^6.0.1",
 		"globby": "^8.0.1",
 		"inquirer": "^6.0.0",
 		"listr": "^0.14.1",

--- a/readme.md
+++ b/readme.md
@@ -65,11 +65,12 @@ Usage
   $ carbon-now <file>
 
 Options
-  -s, --start          Starting line of <file>
-  -e, --end            Ending line of <file>
-  -i, --interactive    Interactive mode
-  -l, --location       Image save location, default: cwd
-  -o, --open           Open in browser instead of saving
+  -s, --start           Starting line of <file>
+  -e, --end             Ending line of <file>
+  -i, --interactive     Interactive mode
+  -l, --location        Image save location, default: cwd
+  -o, --open            Open in browser instead of saving
+  -S, --disable-sandbox Disable sandbox
 ```
 
 ## Examples

--- a/src/headless-visit.js
+++ b/src/headless-visit.js
@@ -1,10 +1,11 @@
 // Packages
 const puppeteer = require('puppeteer');
 
-module.exports = async (url, location = process.cwd(), type = 'png') => {
+module.exports = async (url, location = process.cwd(), type = 'png', disableSandbox = false) => {
 	// Launch browser
 	const browser = await puppeteer.launch({
-		headless: false
+		headless: false,
+		args: disableSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
 	});
 	// Open new page
 	const page = await browser.newPage();

--- a/src/headless-visit.js
+++ b/src/headless-visit.js
@@ -1,11 +1,13 @@
 // Packages
 const puppeteer = require('puppeteer');
+const path = require('path');
+const fs = require('fs');
 
 module.exports = async (url, location = process.cwd(), type = 'png', disableSandbox = false) => {
 	// Launch browser
 	const browser = await puppeteer.launch({
 		headless: false,
-		args: disableSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
+		args: disableSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
 	});
 	// Open new page
 	const page = await browser.newPage();
@@ -27,21 +29,63 @@ module.exports = async (url, location = process.cwd(), type = 'png', disableSand
 		downloadPath: `${location}/`
 	});
 
-	// `page.waitForSelector` https://goo.gl/gGLKBL ➝ exactly what I needed 👍
-	const saveImageTrigger = await page.waitForSelector('[aria-labelledby="downshift-2-label"]');
-	// Only after this is clicked, the png and svg triggers will exist in the DOM
-	await saveImageTrigger.click();
+	await page.addScriptTag({
+		path: path.resolve(__dirname,
+			'..', 
+			'node_modules', 
+			'dom-to-image', 
+			'src', 
+			'dom-to-image.js')
+	});
 
-	const pngExportTrigger = await page.$('#downshift-2-item-0');
-	const svgExportTrigger = await page.$('#downshift-2-item-1');
+	await page.evaluate(() => {
+		if (typeof domtoimage === 'undefined' && module.exports) {
+			window.domtoimage = module.exports;
+		}
+	});
+	
+	const dataUrl = await page.evaluate(() => {
+    const node = document.getElementById('export-container')
 
-	if (type === 'png') {
-		await pngExportTrigger.click();
-	} else if (type === 'svg') {
-		await svgExportTrigger.click();
-	} else {
-		throw new Error('Only png and svg are supported.');
-	}
+		// EXPORT SIZES=1,2,4
+    const exportSize = 2;
+    const width = node.offsetWidth * exportSize;
+    const height = false //true for squared image
+      ? node.offsetWidth * exportSize
+      : node.offsetHeight * exportSize;
+
+    const config = {
+      style: {
+        transform: `scale(${exportSize})`,
+        'transform-origin': 'center',
+        background: 'none' //this.state.squaredImage ? this.state.backgroundColor : 'none'
+      },
+      filter: n => {
+        // %[00 -> 19] cause failures
+        if (
+          n.innerText && n.innerText.match(/%[0-1][0-9]/) &&
+          n.className &&
+          n.className.startsWith('cm-') // is CodeMirror primitive string
+        ) {
+          n.innerText = n.innerText.replace('%', '%25')
+        }
+        if (n.className) {
+          return String(n.className).indexOf('eliminateOnRender') < 0
+        }
+        return true
+      },
+      width,
+      height
+    }
+    // we need regular dataurls
+    return window.domtoimage.toPng(node, config)
+	});
+
+	console.log('fetched data url');
+	const data = dataUrl.slice("data:image/png;base64,".length)
+	const buffer = new Buffer(data, 'base64');
+	fs.writeFileSync('carbon.png', buffer);
+	console.log('wrote image to carbon.png');
 
 	// Wait some more as `waitUntil: 'load'` or `waitUntil: 'networkidle0'
 	// is not always enough, see https://goo.gl/eTuogd

--- a/src/headless-visit.js
+++ b/src/headless-visit.js
@@ -1,13 +1,16 @@
 // Packages
-const puppeteer = require('puppeteer');
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
+const puppeteer = require('puppeteer');
+const renderCode = require('./helpers/render-code');
 
-module.exports = async (url, location = process.cwd(), type = 'png', disableSandbox = false) => {
+const DATA_URL_PREFIX_LENGTH = 22;
+
+module.exports = async (url, location = process.cwd(), settings, disableSandbox = false) => {
 	// Launch browser
 	const browser = await puppeteer.launch({
 		headless: false,
-		args: disableSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
+		args: disableSandbox ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
 	});
 	// Open new page
 	const page = await browser.newPage();
@@ -21,71 +24,14 @@ module.exports = async (url, location = process.cwd(), type = 'png', disableSand
 	await page.goto(url, {
 		waitUntil: 'load' // https://goo.gl/BdRVnv
 	});
-	// Allow files to be downloaded and set it to the CWD
-	// Currently experimental: https://goo.gl/uxYgrW
-	// Let’s hope it remains a thing… 🤞
-	await page._client.send('Page.setDownloadBehavior', {
-		behavior: 'allow',
-		downloadPath: `${location}/`
-	});
 
-	await page.addScriptTag({
-		path: path.resolve(__dirname,
-			'..', 
-			'node_modules', 
-			'dom-to-image', 
-			'src', 
-			'dom-to-image.js')
-	});
+	const data = (await renderCode(page, settings)).slice(DATA_URL_PREFIX_LENGTH);
+	const buffer = Buffer.from(data, 'base64');
 
-	await page.evaluate(() => {
-		if (typeof domtoimage === 'undefined' && module.exports) {
-			window.domtoimage = module.exports;
-		}
-	});
-	
-	const dataUrl = await page.evaluate(() => {
-    const node = document.getElementById('export-container')
+	const file = path.join(location, 'carbon.png');
+	await fs.ensureFile(file);
 
-		// EXPORT SIZES=1,2,4
-    const exportSize = 2;
-    const width = node.offsetWidth * exportSize;
-    const height = false //true for squared image
-      ? node.offsetWidth * exportSize
-      : node.offsetHeight * exportSize;
-
-    const config = {
-      style: {
-        transform: `scale(${exportSize})`,
-        'transform-origin': 'center',
-        background: 'none' //this.state.squaredImage ? this.state.backgroundColor : 'none'
-      },
-      filter: n => {
-        // %[00 -> 19] cause failures
-        if (
-          n.innerText && n.innerText.match(/%[0-1][0-9]/) &&
-          n.className &&
-          n.className.startsWith('cm-') // is CodeMirror primitive string
-        ) {
-          n.innerText = n.innerText.replace('%', '%25')
-        }
-        if (n.className) {
-          return String(n.className).indexOf('eliminateOnRender') < 0
-        }
-        return true
-      },
-      width,
-      height
-    }
-    // we need regular dataurls
-    return window.domtoimage.toPng(node, config)
-	});
-
-	console.log('fetched data url');
-	const data = dataUrl.slice("data:image/png;base64,".length)
-	const buffer = new Buffer(data, 'base64');
-	fs.writeFileSync('carbon.png', buffer);
-	console.log('wrote image to carbon.png');
+	fs.writeFileSync(file, buffer);
 
 	// Wait some more as `waitUntil: 'load'` or `waitUntil: 'networkidle0'
 	// is not always enough, see https://goo.gl/eTuogd

--- a/src/helpers/render-code.js
+++ b/src/helpers/render-code.js
@@ -1,0 +1,53 @@
+/* global window */
+/* global document */
+
+const filter = n => {
+	// %[00 -> 19] cause failures
+	if (
+		n.innerText && n.innerText.match(/%[0-1]\d/) &&
+    n.className &&
+    n.className.startsWith('cm-') // Is CodeMirror primitive string
+	) {
+		n.innerText = n.innerText.replace('%', '%25');
+	}
+	if (n.className) {
+		return String(n.className).indexOf('eliminateOnRender') < 0;
+	}
+	return true;
+};
+
+module.exports = async (page, {es = 2, si = false, type = 'png'}) => {
+	await page.evaluate(() => {
+		window.module = undefined; // Carbon-now.sh has a module.exports variable somehow
+	});
+
+	await page.addScriptTag({
+		path: require.resolve('dom-to-image')
+	});
+
+	return page.evaluate((es, si, type, filter) => {
+		const node = document.getElementById('export-container');
+
+		// EXPORT SIZES=1,2,4
+		const width = node.offsetWidth * es;
+		const height = si ?
+			node.offsetWidth * es :
+			node.offsetHeight * es;
+
+		const config = {
+			style: {
+				transform: `scale(${es})`,
+				'transform-origin': 'center',
+				background: 'none' // This.state.si ? this.state.backgroundColor : 'none'
+			},
+			filter,
+			width,
+			height
+		};
+		// We need regular dataurls
+		if (type === 'svg') {
+			return window.domtoimage.toSvg(node, config);
+		}
+		return window.domtoimage.toPng(node, config);
+	}, es, si, type, filter);
+};

--- a/test/headless-visit.test.js
+++ b/test/headless-visit.test.js
@@ -31,7 +31,7 @@ test('Downloads code image correctly', async t => {
 		}
 
 		// Download image
-		await headlessVisit('https://carbon.now.sh');
+		await headlessVisit('https://carbon.now.sh', process.cwd(), {}, true);
 
 		// If it exists, pass
 		t.true((await globby([defaultDownloadName])).length > 0);
@@ -41,7 +41,7 @@ test('Downloads code image correctly', async t => {
 });
 
 test('Respects download location', async t => {
-	await headlessVisit('https://carbon.now.sh', downloadDir);
+	await headlessVisit('https://carbon.now.sh', downloadDir, {}, true);
 
 	t.true((await globby([fullDownloadPath])).length > 0);
 });


### PR DESCRIPTION
This PR changes the way images are rendered and downloaded, so that this tool doesn't depend on experimental (and unstable) chromium features anymore.
Instead of simulating a click on the download button, the function to generate the image was taken from carbon-now.sh
Unfortunately we have some merge conflicts here, but I hope we can solve them fast and merge this, so the cli will work for everybody :)