### PR TITLE
Parse start and end line numbers as numbers, not strings

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -46,12 +46,12 @@ const cli = meow(`
 {
 	flags: {
 		start: {
-			type: 'string',
+			type: 'number',
 			alias: 's',
 			default: 1
 		},
 		end: {
-			type: 'string',
+			type: 'number',
 			alias: 'e',
 			default: 1000
 		},

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -56,6 +56,17 @@ test.serial('Doesn’t modify local config, treats it as read-only', async t => 
 	t.is(BEFORE, AFTER);
 });
 
+test.serial('Make sure the end line is larger that start line', async t => {
+	await execa(SCRIPT, [
+		DUMMY_FROM,
+		'--start=2',
+		'--end=10',
+		`-t=${DUMMY_TARGET_NAME}`
+	]);
+
+	t.true(await fileExists(DUMMY_FILE_NAME));
+});
+
 // Cleanup
 test.afterEach((async () => {
 	await del([

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -56,7 +56,7 @@ test.serial('Doesn’t modify local config, treats it as read-only', async t => 
 	t.is(BEFORE, AFTER);
 });
 
-test.serial('Make sure the end line is larger that start line', async t => {
+test.serial('Makes sure the end line is larger than start line', async t => {
 	await execa(SCRIPT, [
 		DUMMY_FROM,
 		'--start=2',


### PR DESCRIPTION
Using the `--start` and `--end` can fail the check that the end line is larger than the start line because the comparison is done using strings instead of the numerical value.

Fixes #34 