### PR TITLE
language-map: add support for plain text (.txt)

### DIFF
--- a/src/helpers/language-map.json
+++ b/src/helpers/language-map.json
@@ -116,6 +116,7 @@
 	["ttl", "turtle"],
 	["ts", "application/typescript"],
 	["tsx", "application/typescript"],
+	["txt", "text"],
 	["vb", "vb"],
 	["v", "verilog"],
 	["vhdl", "vhdl"],


### PR DESCRIPTION
I was just trying to render some plain text files in carbon-now and the auto language detection decided on some weird coloring that doesn't make sense to me. Hopefully 'text' is a better default for .txt files.