### PR TITLE
Fix/remove bash prompt in install code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,17 +48,17 @@ Want to customize **everything** before generating the image? Run it in ⚡️ *
 
 #### npm
 ```
-$ npm i -g carbon-now-cli
+npm i -g carbon-now-cli
 ```
 
 #### yarn
 ```
-$ yarn global add carbon-now-cli
+yarn global add carbon-now-cli
 ```
 
 #### npx
 ```
-$ npx carbon-now-cli <file>
+npx carbon-now-cli <file>
 ```
 
 #### Requirements

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ yarn global add carbon-now-cli
 
 #### npx
 ```
-npx carbon-now-cli <file>
+$ npx carbon-now-cli <file>
 ```
 
 #### Requirements


### PR DESCRIPTION
Copying the installation code also includes the `$` sign.

Now the user has to click on the copy clipboard;
Remove the dollar sign manually;
And paste it into the terminal.

Removing this `$` sign in the install code snippet eliminate one movement.